### PR TITLE
Copy DATA_README, `templates` and `tests` READMEs from Publisher

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -29,7 +29,7 @@ collapsible_nav: true
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level
 # headings.
-max_toc_heading_level: 6
+max_toc_heading_level: 3
 
 # Prevent robots from indexing (e.g. whilst in development)
 prevent_indexing: true

--- a/source/architecture.html.md.erb
+++ b/source/architecture.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-weight: 15
+weight: 20
 ---
 
 # Architecture of Ethnicity Facts and Figures

--- a/source/chart-table-builder-partials/chart-and-table-builders.md
+++ b/source/chart-table-builder-partials/chart-and-table-builders.md
@@ -7,11 +7,11 @@ particular to Tablebuilder should be minor.
 
 Charts in the Ethnicity Facts and Figures ecosystem work on three files:
 
-- `templates/cms/create_chart.html` is the template that contains the chartbuilder form.
-- `rd-chart-objects.js` is a factory for building rd-chart objects.
-- `rd-graph.js` is a renderer for rendering rd-chart objects.
+- `templates/cms/create_chart.html` is the template that contains the chartbuilder form
+- `rd-chart-objects.js` is a factory for building rd-chart objects
+- `rd-graph.js` is a renderer for rendering rd-chart objects
 
-Some common functions between the table builder and chart builder are also stored in `rd-builder.js`
+Some common functions between the table builder and chart builder are also stored in `rd-builder.js`.
 
 On **Save** the chartbuilder builds a rd-chart object which it sends to be stored on the dimension for rendering by 
 rd-graph. It also sends a json dump of all the current builder settings so it can recall them next time this chart is 
@@ -25,16 +25,16 @@ On the back-end it is supported by EthnicityClassificationFinder.
 
 Chartbuilder has the handleNewData(success) function at its heart
 
-- User pastes excel content as text into the data box and clicks `Next`.
-- `handleNewData(success)` is triggered and makes an AJAX call to the EthnicityClassificationFinder endpoint. A list of 
-  EthnicityClassificationFinder classifications with processed data is returned.
+- User pastes excel content as text into the data box and clicks `Next`
+- `handleNewData(success)` is triggered and makes an AJAX call to the EthnicityClassificationFinder endpoint; a list of 
+  EthnicityClassificationFinder classifications with processed data is returned
 - The success function stores all the valid EthnicityClassificationFinder classifications (and their converted data) 
-  client side. It picks the first classification for preference then sets up the rest of the builder form using data 
-  from that classification.
+  client side - it picks the first classification for preference then sets up the rest of the builder form using data 
+  from that classification
 - When changes are made to any setting chartbuilder builds a chart object and renders in the chart area using the 
   standard values
 - Save posts an AJAX call to the Publisher's chartbuilder endpoint with a chart object and the current builder settings,
-  both as lumps of json. These are stored as json objects in the database.
-- If the builder is reopened it will fill the data text box from the settings. It then calls `handleNewData(success)`
-  which builds classifications. At the end of the regular success function it uses the rest of the settings object to 
-  set up the existing chart.
+  both as lumps of JSON (these are stored as json objects in the database)
+- If the builder is reopened it will fill the data text box from the settings and call `handleNewData(success)`,
+  which builds classifications
+- At the end of the regular success function it uses the rest of the settings object to set up the existing chart

--- a/source/chart-table-builder-partials/chart-and-table-builders.md
+++ b/source/chart-table-builder-partials/chart-and-table-builders.md
@@ -1,0 +1,40 @@
+## Chartbuilder and Tablebuilder
+
+Chartbuilder and Tablebuilder function in roughly the same way. Chartbuilder will be detailed here and anything 
+particular to Tablebuilder should be minor.
+
+### Charts in the Publisher
+
+Charts in the Ethnicity Facts and Figures ecosystem work on three files:
+
+- `templates/cms/create_chart.html` is the template that contains the chartbuilder form.
+- `rd-chart-objects.js` is a factory for building rd-chart objects.
+- `rd-graph.js` is a renderer for rendering rd-chart objects.
+
+Some common functions between the table builder and chart builder are also stored in `rd-builder.js`
+
+On **Save** the chartbuilder builds a rd-chart object which it sends to be stored on the dimension for rendering by 
+rd-graph. It also sends a json dump of all the current builder settings so it can recall them next time this chart is 
+opened up.
+
+#### Chartbuilder
+
+On the back-end it is supported by EthnicityClassificationFinder.
+
+#### How it works
+
+Chartbuilder has the handleNewData(success) function at its heart
+
+- User pastes excel content as text into the data box and clicks `Next`.
+- `handleNewData(success)` is triggered and makes an AJAX call to the EthnicityClassificationFinder endpoint. A list of 
+  EthnicityClassificationFinder classifications with processed data is returned.
+- The success function stores all the valid EthnicityClassificationFinder classifications (and their converted data) 
+  client side. It picks the first classification for preference then sets up the rest of the builder form using data 
+  from that classification.
+- When changes are made to any setting chartbuilder builds a chart object and renders in the chart area using the 
+  standard values
+- Save posts an AJAX call to the cms chartbuilder endpoint with a chart object and the current builder settings, both as
+  lumps of json. These are stored as json objects in the database.
+- If the builder is reopened it will fill the data text box from the settings. It then calls `handleNewData(success)`
+  which builds classifications. At the end of the regular success function it uses the rest of the settings object to 
+  set up the existing chart.

--- a/source/chart-table-builder-partials/chart-and-table-builders.md
+++ b/source/chart-table-builder-partials/chart-and-table-builders.md
@@ -33,8 +33,8 @@ Chartbuilder has the handleNewData(success) function at its heart
   from that classification.
 - When changes are made to any setting chartbuilder builds a chart object and renders in the chart area using the 
   standard values
-- Save posts an AJAX call to the cms chartbuilder endpoint with a chart object and the current builder settings, both as
-  lumps of json. These are stored as json objects in the database.
+- Save posts an AJAX call to the Publisher's chartbuilder endpoint with a chart object and the current builder settings,
+  both as lumps of json. These are stored as json objects in the database.
 - If the builder is reopened it will fill the data text box from the settings. It then calls `handleNewData(success)`
   which builds classifications. At the end of the regular success function it uses the rest of the settings object to 
   set up the existing chart.

--- a/source/chart-table-builder-partials/ethnicity-classification.md
+++ b/source/chart-table-builder-partials/ethnicity-classification.md
@@ -1,0 +1,66 @@
+## EthnicityClassificationFinder
+
+### Ethnicity standards problem
+
+Departments use a list of over 250 different ethnicity labels in their spreadsheets.
+We need to turn the mixture of ethnicity values we get from departments into a standard list.
+The list we map to has 39 values that are a variety on the ONS 2011 census values.
+Also we also need to assign structure to our data: parents and order.
+
+There are two aspects to our problem...
+
+**Non-standard values.** The base problem arrives because departments code a standard ethnicity of "White British" 
+in different ways
+
+- White British
+- White England/NI/Scotland/Wales
+- British: White
+- White: British
+
+Converting one set of values to another set of values using a lookup table is well established.
+Building the dictionary is an extensive task but this should, at least, be a solved problem. Not so for us due to...
+
+**Contextual variation.** Any given dataset is consistent in itself. On a broad level you get contradiction.
+In other words when the DfE say Asian it may mean something different to when the MoJ say Asian (and in fact does).
+
+The worst offender is "Other". Depending on the original data set "Other" may need to become
+
+- Other
+- Other inc Chinese
+- Other inc Mixed
+- Other inc Asian
+- Any ethnicity other than White
+- Any ethnicity other than White British
+
+Context can also change structure. For example "Chinese" maps to "Chinese" in any situation but is a child of "Asian" 
+in the 2011 census and a child of "Other inc Chinese" in 2001.
+
+### Solution 1: EthnicityDictionaryLookup
+
+*EthnicityDictionaryLookup has now been removed from the codebase but notes are left here for historical interest.*
+
+There is a standard way to share data with ambiguous columns such as Ethnicity. That is to mark each cell with the 
+schema it's data belongs to.
+When we shipped our original templates to departments we required an "Ethnicity Type" with each row of data. We could 
+use a double lookup on Ethnicity and Type to map to useful values.
+
+Building the *"data dictionary"* was a large task and remained ongoing throughout the lifespan. The mapping task is the 
+job of **EthnicityDictionaryLookup**. It maps [Ethnicity, Ethnicity Type] to [Standard Ethnicity, Parent, Parent-child 
+order]. In the event of Ethnicity Type being absent or unrecognisable we had a default as part of the dictionary.
+
+**Problem:** This system relies on Ethnicity Type being robust and it isn't. The ideal of having a common language of 
+Ethnicity and Classification definitions across government is only a dream at present. This results with default being 
+used most of the time and the flexibility of DictionaryLookup could not be exploited.
+
+### Solution 2: EthnicityClassificationFinder
+
+Solution 2 regards the **non-standard values** and **contextual variation** problems as distinct. It allows you to 
+standardise ethnicity without having to rely on data providers or spend time cleaning Ethnicity Type data. This is 
+possible due to the familiarity we have built with ethnicity categorisations.
+
+In stage 1 EthnicityClassificationFinder converts raw-values received from departments into a standard list used across 
+RDU.
+
+In stage 2 it takes the outputs from stage 1 and determines which of known ethnicity classifications might apply. We 
+store a list of "Ethnicity type classifications" such as "ONS 2001 5+1" and "White British and other". These contain 
+information on how data with that Ethnicity type should be displayed.

--- a/source/chart-table-builder.html.md.erb
+++ b/source/chart-table-builder.html.md.erb
@@ -1,0 +1,9 @@
+---
+title: Data README
+weight: 25
+---
+
+# Data README
+
+<%= partial 'chart-table-builder-partials/ethnicity-classification' %>
+<%= partial 'chart-table-builder-partials/chart-and-table-builders' %>

--- a/source/chart-table-builder.html.md.erb
+++ b/source/chart-table-builder.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Data README
-weight: 25
+weight: 50
 ---
 
 # Data README

--- a/source/data-model.html.md.erb
+++ b/source/data-model.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Data model
-weight: 17
+weight: 30
 last_reviewed_on: 2019-04-29
 review_in: 12 weeks
 ---

--- a/source/maintenance.html.md.erb
+++ b/source/maintenance.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Maintenance mode
-weight: 30
+weight: 70
 ---
 
 # Maintenance mode

--- a/source/publisher-partials/build-static-site.md
+++ b/source/publisher-partials/build-static-site.md
@@ -11,8 +11,8 @@ The static site build process can be run manually via the following script:
 ./manage.py force_build_static_site
 ```
 
-In order to initiate builds automatically in response to user actions in the CMS (eg publishing a new page), a `build`
-table acts as a basic job queue. New rows are added to this table whenever a build is requested.
+In order to initiate builds automatically in response to user actions in the Publisher (eg publishing a new page), a 
+`build` table acts as a basic job queue. New rows are added to this table whenever a build is requested.
 
 To actually run these requested builds, the following script needs to be run at regular intervals:
 

--- a/source/publisher-partials/developer-setup.md
+++ b/source/publisher-partials/developer-setup.md
@@ -179,7 +179,7 @@ With these set, run the following management tasks:
 scripts/run_tests.sh
 ```
 
-### Run the CMS app
+### Run the Publisher app
 
 To run the application server:
 
@@ -187,7 +187,7 @@ To run the application server:
 scripts/run.sh
 ```
 
-By default the CMS will be served at [http://localhost:5000](http://localhost:5000)
+By default the Publisher will be served at [http://localhost:5000](http://localhost:5000)
 
 To run the Gulp build process for static assets (CSS and javascript) whenever they are changed:
 

--- a/source/publisher.html.md.erb
+++ b/source/publisher.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Publisher README
-weight: 20
+weight: 40
 ---
 
 # Publisher README

--- a/source/redirects.html.md.erb
+++ b/source/redirects.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Redirects
-weight: 40
+weight: 80
 ---
 
 # Redirects

--- a/source/templates-partials/templates.md
+++ b/source/templates-partials/templates.md
@@ -1,0 +1,60 @@
+Our site templates are all derived from a single base template, `base.html`, at the root of the templates directory.
+The base template declares the interface for all sub-templates and exposes a number of blocks that can be overriden,
+as needed, to customise content and structure. The exposed interface consists of the following blocks (closely
+derived from the [GOV.UK Design System](https://design-system.service.gov.uk/styles/page-template)):
+
+* pageTitle
+    * The name of the page as it appears next to the favicon (i.e. in the window/tab).
+* headIcons
+    * Override the default icons used for the page.
+* socialMetadata
+    * Wraps around a set of blocks that define attributes for Open Graph and other social-sharing protocols.
+    * Helps links to our site render nicely and with useful metadata when shared socially via other sites.
+    * Sub-blocks:
+        * socialType
+            * Sets the type of page being shared (for us, our pages are generally of the `article` type)
+        * socialTitle
+            * The title of the page as it should appear when shared
+        * socialDescription
+            * A short description of the page to provide a summary or some context when shared
+        * socialImage
+            * An image to be displayed for the page when shared
+        * twitterMetadata
+            * Additional metadata that extends the Open Graph protocol specifically for Twitter.
+    * See also http://ogp.me, https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started
+* httpEquiv
+    * Declares and defines any `http-equiv` meta attributes for the page, currently used for the inline Content Security Policy.
+* googleAnalytics
+    * A hook into the inline JavaScript that configures our Google Analytics for each page.
+* headEnd
+    * A hook into the end of the `<head>` element.
+* bodyClasses
+    * Can be used to set the `class` attribute on the `<body>` element.
+* bodyStart
+    * A hook into the start of the `<body>` element.
+* cookieMessage
+    * Contains the global GOV.UK cookie messages
+* header
+    * Contains the default page header for the site, including the CMS header (if appropriate)
+* phaseBanner
+    * Wraps around the phase (beta) banner, used to override it on the homepage to invert the colours.
+* main
+    * Wrapper around the declaration of the `<main>` element.
+    * Sub-blocks:
+        * beforeContent
+            * A hook within the main content container, but before and outside the `main` element.
+            * Sub-blocks:
+                * breadcrumbs
+                    * Renders the breadcrumbs for the page, using the `breadcrumbs` variable defined in each sub-template.
+                * flashMessages
+                    * Renders flash messages for the page, retrieving them from `get_flashed_messages` exposed by Flask.
+                * errorSummary
+                    * Renders an error summary for any forms on the page, populated from the `errors` variable.
+        * mainAttributes
+            * A hook into additional attributes for the `main` element.
+        * content
+            * Where sub-templates should declare the content for the specific page, including its `<h1>`.
+* footer
+    * Wraps the default footer of the page, should it need to be overriden.
+* bodyEnd
+    * A section just before the closing tag of the `<body>` element to include - most likely - scripts on the page. By default, this includes the main scripts for the site - such as `all.js` for the static site, and `cms.js`/`charts.js` for the CMS.

--- a/source/templates-partials/templates.md
+++ b/source/templates-partials/templates.md
@@ -4,12 +4,12 @@ as needed, to customise content and structure. The exposed interface consists of
 derived from the [GOV.UK Design System](https://design-system.service.gov.uk/styles/page-template)):
 
 * pageTitle
-    * The name of the page as it appears next to the favicon (i.e. in the window/tab).
+    * The name of the page as it appears next to the favicon (i.e. in the window/tab)
 * headIcons
-    * Override the default icons used for the page.
+    * Override the default icons used for the page
 * socialMetadata
-    * Wraps around a set of blocks that define attributes for Open Graph and other social-sharing protocols.
-    * Helps links to our site render nicely and with useful metadata when shared socially via other sites.
+    * Wraps around a set of blocks that define attributes for Open Graph and other social-sharing protocols
+    * Helps links to our site render nicely and with useful metadata when shared socially via other sites
     * Sub-blocks:
         * socialType
             * Sets the type of page being shared (for us, our pages are generally of the `article` type)
@@ -20,41 +20,43 @@ derived from the [GOV.UK Design System](https://design-system.service.gov.uk/sty
         * socialImage
             * An image to be displayed for the page when shared
         * twitterMetadata
-            * Additional metadata that extends the Open Graph protocol specifically for Twitter.
-    * See also http://ogp.me, https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started
+            * Additional metadata that extends the Open Graph protocol specifically for Twitter
+    * See also [http://ogp.me](http://ogp.me), [https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started)
 * httpEquiv
-    * Declares and defines any `http-equiv` meta attributes for the page, currently used for the inline Content Security Policy.
+    * Declares and defines any `http-equiv` meta attributes for the page, currently used for the inline Content Security Policy
 * googleAnalytics
-    * A hook into the inline JavaScript that configures our Google Analytics for each page.
+    * A hook into the inline JavaScript that configures our Google Analytics for each page
 * headEnd
-    * A hook into the end of the `<head>` element.
+    * A hook into the end of the `<head>` element
 * bodyClasses
-    * Can be used to set the `class` attribute on the `<body>` element.
+    * Can be used to set the `class` attribute on the `<body>` element
 * bodyStart
-    * A hook into the start of the `<body>` element.
+    * A hook into the start of the `<body>` element
 * cookieMessage
     * Contains the global GOV.UK cookie messages
 * header
     * Contains the default page header for the site, including the CMS header (if appropriate)
 * phaseBanner
-    * Wraps around the phase (beta) banner, used to override it on the homepage to invert the colours.
+    * Wraps around the phase (beta) banner, used to override it on the homepage to invert the colours
 * main
-    * Wrapper around the declaration of the `<main>` element.
+    * Wrapper around the declaration of the `<main>` element
     * Sub-blocks:
         * beforeContent
-            * A hook within the main content container, but before and outside the `main` element.
+            * A hook within the main content container, but before and outside the `main` element
             * Sub-blocks:
                 * breadcrumbs
-                    * Renders the breadcrumbs for the page, using the `breadcrumbs` variable defined in each sub-template.
+                    * Renders the breadcrumbs for the page, using the `breadcrumbs` variable defined in each sub-template
                 * flashMessages
-                    * Renders flash messages for the page, retrieving them from `get_flashed_messages` exposed by Flask.
+                    * Renders flash messages for the page, retrieving them from `get_flashed_messages` exposed by Flask
                 * errorSummary
-                    * Renders an error summary for any forms on the page, populated from the `errors` variable.
+                    * Renders an error summary for any forms on the page, populated from the `errors` variable
         * mainAttributes
-            * A hook into additional attributes for the `main` element.
+            * A hook into additional attributes for the `main` element
         * content
-            * Where sub-templates should declare the content for the specific page, including its `<h1>`.
+            * Where sub-templates should declare the content for the specific page, including its `<h1>`
 * footer
-    * Wraps the default footer of the page, should it need to be overriden.
+    * Wraps the default footer of the page, should it need to be overridden
 * bodyEnd
-    * A section just before the closing tag of the `<body>` element to include - most likely - scripts on the page. By default, this includes the main scripts for the site - such as `all.js` for the static site, and `cms.js`/`charts.js` for the CMS.
+    * A section just before the closing tag of the `<body>` element, most likely to include scripts for the page; 
+      by default this includes the main scripts for the site - such as `all.js` for the static site, and 
+      `cms.js`/`charts.js` for the CMS

--- a/source/templates.html.md.erb
+++ b/source/templates.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Template structure
-weight: 27
+weight: 60
 ---
 
 # Template structure

--- a/source/templates.html.md.erb
+++ b/source/templates.html.md.erb
@@ -1,0 +1,8 @@
+---
+title: Template structure
+weight: 27
+---
+
+# Template structure
+
+<%= partial 'templates-partials/templates' %>

--- a/source/test-setup-partials/factory-boy.md
+++ b/source/test-setup-partials/factory-boy.md
@@ -1,0 +1,68 @@
+## Factory Boy
+We use [Factory Boy](https://factoryboy.readthedocs.io/en/latest/introduction.html) to generate realistic model 
+instances to test against. This replaces, in most places, the use of [pytest fixtures](https://docs.pytest.org/en/latest/fixture.html),
+and going forward should be the preferred way of generating test data. Using the existing factories should have a 
+relatively small learning curve beyond knowing the interface exposed by our models. If the models change, the 
+corresponding factories should be updated as well, in which case it is expected that you'll need to spend some time 
+becoming familiar with how Factory Boy works.
+
+Using these factories should be fairly intuitive once you're familiar with our models - you simply instantiate the 
+factory and pass in parameters as keywords using the model attributes. The attributes of related models can be set 
+during instantiation by separating with a double underscore (see examples below). Any arguments not specified will be 
+filled in with random realistic data by the factory. Most of the factories mirror our models exactly, with some minor 
+exceptions. Given the related nature of a lot of our models, and their dependecy on other models, using one factory may 
+mean that multiple records are created across different tables.
+
+The main principle used when defining our factories is that relationships of the factory that are farther away from 
+MeasureVersion should be created. Referring to our Data Model will help appreciate the implications of this, but it 
+should suffice to say that the MeasureVersion is considered the "centre" of the current model. Instantiating a 
+MeasureVersion, therefore, creates many related records, whereas instantiating a Measure will create far fewer.
+
+For example:
+
+* MeasureFactory will create a Measure, as well as a related Subtopic and Topic
+* ClassificationFactory will create a Classification, as well as some Ethnicities, and links to those ethnicities as
+  parent and child values
+* A MeasureVersionFactory will create a Measure, Subtopic, Topic, Upload, Lowest Level of Geography, etc
+
+Notably, the default MeasureVersionFactory does _not_ create any dimensions by default. An alternative factory,
+MeasureVersionWithDimensionFactory, exists to do this, as creating a Dimension requires instantiating a lot of extra
+models, so does not feel like an appropriate or useful default.
+
+Example usage:
+
+* Creating a measure:
+    ```
+    measure = MeasureFactory()
+    ```
+    Instantiates a Measure, with related Subtopic and Topic, all with random unspecified data
+* Creating a measure version:
+    ```
+    measure_version = MeasureVersionFactory(status='DRAFT')
+    ```
+    This will create a MeasureVersion populated in the 'DRAFT' state, with all other data randomly-generated, with 
+    associated users, Measure, Subtopic, Topic, Upload, Data Source, Level of Geography, but **not** a Dimension
+* Creating a measure version with a dimension:
+    ```
+    measure_version = MeasureVersionWithDimensionFactory(status='PUBLISHED', dimensions__title='My dimension')
+    ```
+    This creates a MeasureVersion in the 'PUBLISHED' state, with all other data randomly-generated, with all associated 
+    records **including** one Dimension, and that Dimension's title will be 'My dimension'
+* Creating a dimension:
+    ```
+    dimension = DimensionFactory(summary="Dimension summary", dimension_chart=None)
+    ```
+    This will create a Dimension with the given summary, no associated Chart, and all other data randomly-generated -
+    it **will not** generate a MeasureVersion by default (a dimension is not valid without an associated MeasureVersion,
+    so one will need to be created and the dimension attached to it before a database commit will succeed)
+* Creating a dimension and attaching it to an existing MeasureVersion:
+    ```
+    dimension = DimensionFactory(measure_version=measure_version)
+    ```
+    Creates a Dimension and sets up the `page` relationship to point to an existing MeasureVersion
+* Creating a Classification:
+    ```
+    classification = ClassificationFactory()
+    ```
+    This will create a random Classification, a set of Ethnicities (chosen from bird, cat, dog, and specific breeds of 
+    those), and some child and parent links between Classification and Ethnicity

--- a/source/test-setup-partials/tests.md
+++ b/source/test-setup-partials/tests.md
@@ -1,0 +1,20 @@
+## Tests
+
+Our unit tests are found in `tests/application/` and mirror the structure of the top-level `application/` module. 
+Our end-to-end tests are more free-form and found under `tests/functional/`.
+
+## How our tests work
+
+We make liberal use of [pytest fixtures](https://docs.pytest.org/en/latest/fixture.html) to minimise the amount of 
+boilerplate setup code we need to write for each test. These are found in `conftest.py` files.
+
+Some of our fixtures are applied automatically to all tests. Important examples are:
+
+* A full database migration runs at the start of each test session  
+  [see `conftest:db_migration`]
+* Before **every** test, all records from the database are removed (EXCEPT materialized views, which need to be 
+  refreshed on an as-needed basis within the test that needs them)  
+  [see `conftest:db_session`]
+* All network requests via the `requests` library are mocked out to raise exceptions, with the aim of preventing (most)
+  requests from reaching out to the Internet  
+  [see `conftest:requests_mocker`]

--- a/source/test-setup.html.md.erb
+++ b/source/test-setup.html.md.erb
@@ -1,0 +1,9 @@
+---
+title: Testing
+weight: 55
+---
+
+# Test setup
+
+<%= partial 'test-setup-partials/tests' %>
+<%= partial 'test-setup-partials/factory-boy' %>


### PR DESCRIPTION
This PR:
* Resticts the table of contents to three levls of heading
* Copies [README_DATA.md](https://github.com/racedisparityaudit/ethnicity-facts-and-figures-publisher/blob/master/README_DATA.md) with minimal changes (some punctuation and capitalisation changes for consistency, plus style guide fixes)
* Renames CMS to Publisher where it makes sense to
* Copies the [README](https://github.com/racedisparityaudit/ethnicity-facts-and-figures-publisher/blob/master/application/templates/README.md) from the `templates` folder in Publisher (with style guide fixes)
* Copies the [README](https://github.com/racedisparityaudit/ethnicity-facts-and-figures-publisher/blob/master/tests/README.md) from the `tests` folder in Publisher (with style guide fixes)