### PR TITLE
Update `.env` notes

### DIFF
--- a/source/developer-setup.html.md.erb
+++ b/source/developer-setup.html.md.erb
@@ -85,6 +85,9 @@ DATABASE_URL=postgresql://postgres@localhost:5432/rdcms
 TEST_DATABASE_URL=postgresql://postgres@localhost:5432/rdcms_test
 PGSSLMODE=prefer
 
+# Set the log level of the application (from https://docs.python.org/3/library/logging.html#levels)
+LOG_LEVEL=INFO
+
 # SECRET_KEY is used by Flask for creating tokens for password reset and review pages
 SECRET_KEY=[whatever you like]
 LOGIN_DISABLED=False

--- a/source/developer-setup.html.md.erb
+++ b/source/developer-setup.html.md.erb
@@ -83,7 +83,7 @@ FLASK_ENV=development
 ENVIRONMENT=DEVELOPMENT
 DATABASE_URL=postgresql://postgres@localhost:5432/rdcms
 TEST_DATABASE_URL=postgresql://postgres@localhost:5432/rdcms_test
-PGSSLMODE=allow
+PGSSLMODE=prefer
 
 # SECRET_KEY is used by Flask for creating tokens for password reset and review pages
 SECRET_KEY=[whatever you like]


### PR DESCRIPTION
* Prefer SSL connections to postgres (try SSL first, then no SSL). This should probably be `require` - but that feels like it will hamper local development as we don't have SSL set up there?
* Add documentation around `LOG_LEVEL` env