### PR TITLE
 Describe the manual unpublishing process

### DIFF
--- a/source/runbook-partials/redirect.md
+++ b/source/runbook-partials/redirect.md
@@ -18,10 +18,6 @@
     2. Go to invalidations
     3. Create an invalidation for `/*`
 
-<style>
-.govuk-warning-text{font-family:nta,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:400;font-size:16px;font-size:1rem;line-height:1.25;color:#0b0c0c;position:relative;margin-bottom:20px;padding:10px 0}@media print{.govuk-warning-text{font-family:sans-serif}}@media (min-width:40.0625em){.govuk-warning-text{font-size:19px;font-size:1.1875rem;line-height:1.31579}}@media print{.govuk-warning-text{font-size:14pt;line-height:1.15;color:#000}}@media (min-width:40.0625em){.govuk-warning-text{margin-bottom:30px}}.govuk-warning-text_assistive{position:absolute!important;width:1px!important;height:1px!important;margin:-1px!important;padding:0!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;-webkit-clip-path:inset(50%)!important;clip-path:inset(50%)!important;border:0!important;white-space:nowrap!important}.govuk-warning-texticon{font-family:nta,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:700;display:inline-block;position:absolute;top:50%;left:0;min-width:32px;min-height:29px;margin-top:-20px;padding-top:3px;border:3px solid #0b0c0c;border-radius:50%;color:#fff;background:#0b0c0c;font-size:1.6em;line-height:29px;text-align:center;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}@media print{.govuk-warning-texticon{font-family:sans-serif}}.govuk-warning-text_text{display:block;margin-left:-15px;padding-left:65px}
-</style>
-
 <div class="govuk-warning-text">
     <span class="govuk-warning-texticon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text_text">

--- a/source/runbook-partials/unpublishing.md
+++ b/source/runbook-partials/unpublishing.md
@@ -1,0 +1,19 @@
+## Unpublishing a measure version
+
+1. With the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) installed, run the command below to put it
+   back in the 'draft' state, removing all attributes which get set during the publishing process
+    * `heroku run -a <app> ./manage.py unpublish_measure_version --topic_slug <topic_slug> --subtopic_slug <subtopic_slug> --measure_slug <measure_slug> --version <version>`
+        * `<app>` is the name of the Heroku app, e.g. `rd-cms-production`
+        * `<topic_slug>` is the URL slug of the topic, e.g. `health`
+        * `<subtopic_slug>` is the URL slug of the subtopic, e.g. `exercise-and-activity`
+        * `<measure_slug>` is the URL slug of the measure, e.g. `physical-activity`
+        * `<version>` is the major.minor version to unpublish, e.g. `1.1`
+2. Go to the [AWS Console](http://console.aws.amazon.com/) and log in with your RDU user account
+3. Go to the [S3 console](https://s3.console.aws.amazon.com) and go into the static site bucket(s) for the relevant environment
+    * Note: for environments where we have S3 bucket replication set up, make sure to set redirects separately on each bucket
+4. Navigate to the object path prefix for the given measure.
+5. Delete the folder for the given version.
+6. [Recommended]: Clear the [CloudFront](https://console.aws.amazon.com/cloudfront/home) cache by creating an invalidation on the environment's distribution:
+    1. Click on the ID of the distribution
+    2. Go to invalidations
+    3. Create an invalidation for `/*`

--- a/source/runbook.html.md.erb
+++ b/source/runbook.html.md.erb
@@ -3,6 +3,10 @@ title: Runbook
 weight: 1000
 ---
 
+<style>
+.govuk-warning-text{font-family:nta,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:400;font-size:16px;font-size:1rem;line-height:1.25;color:#0b0c0c;position:relative;margin-bottom:20px;padding:10px 0}@media print{.govuk-warning-text{font-family:sans-serif}}@media (min-width:40.0625em){.govuk-warning-text{font-size:19px;font-size:1.1875rem;line-height:1.31579}}@media print{.govuk-warning-text{font-size:14pt;line-height:1.15;color:#000}}@media (min-width:40.0625em){.govuk-warning-text{margin-bottom:30px}}.govuk-warning-text_assistive{position:absolute!important;width:1px!important;height:1px!important;margin:-1px!important;padding:0!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;-webkit-clip-path:inset(50%)!important;clip-path:inset(50%)!important;border:0!important;white-space:nowrap!important}.govuk-warning-texticon{font-family:nta,Arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:700;display:inline-block;position:absolute;top:50%;left:0;min-width:32px;min-height:29px;margin-top:-20px;padding-top:3px;border:3px solid #0b0c0c;border-radius:50%;color:#fff;background:#0b0c0c;font-size:1.6em;line-height:29px;text-align:center;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}@media print{.govuk-warning-texticon{font-family:sans-serif}}.govuk-warning-text_text{display:block;margin-left:-15px;padding-left:65px}
+</style>
+
 # Runbook
 
 <%= partial 'runbook-partials/maintenance-mode.md' %>

--- a/source/runbook.html.md.erb
+++ b/source/runbook.html.md.erb
@@ -11,3 +11,4 @@ weight: 1000
 
 <%= partial 'runbook-partials/maintenance-mode.md' %>
 <%= partial 'runbook-partials/redirect' %>
+<%= partial 'runbook-partials/unpublishing' %>

--- a/source/unpublishing-pages.html.md.erb
+++ b/source/unpublishing-pages.html.md.erb
@@ -1,0 +1,14 @@
+---
+title: Data model
+weight: 80
+---
+
+# Unpublishing pages
+
+As a rule of thumb, we should never need to unpublish a page or set of pages. If a measure has been published that contains
+inaccuracies or bad data, we will publish an update - but continue to make the 'wrong' version available for reference.
+This is part of publishing statistics in an open and transparent manner.
+
+Only in exceptional circumstances do we anticipate there might be a need to, temporarily or otherwise, make a page
+unavailable (defacement, compliance, etc). In these emergencies, there is guidance for
+[unpublishing a measure version](runbook.html#unpublishing-a-measure-version).


### PR DESCRIPTION
We no longer have support for 'unpublishing' measures built-in to the
Publisher. We made this choice explicitly so that it is not a step that
can be easily done - once we publish a page, it's out there in the
public eye and to retract it could put us in a bad light. We should
publish an updated version that corrects and mistakes, instead.

However, we anticipate there *might* be some cases where we need to
unpublish a thing. Where this is the case, it will probably be a
high-stress situation, so documenting the manual process for
unpublishing seems key.

 ## Ticket
https://trello.com/c/7IkxeDcb